### PR TITLE
Refactor scaffolding tool to support multiple templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Go Scaffold Tool
 
-A powerful command-line tool for scaffolding new Go web projects with a clean, organized structure following Go best practices.
+A powerful command-line tool for scaffolding new Go projects with multiple templates based on popular Go project setups.
 
 ## 🚀 Features
 
-- **Clean Architecture**: Creates projects with proper separation of concerns
-- **Go Best Practices**: Follows standard Go project layout conventions
-- **Web-Ready**: Includes basic HTTP server setup and configuration
+- **Multiple Templates**: Choose from full-stack, CLI, API, or library templates
+- **Clean Architecture**: Templates follow Go best practices
+- **Go Best Practices**: Standard Go project layout conventions
+- **Web-Ready**: Full-stack template includes basic HTTP server setup
 - **Dependency Management**: Automatically initializes Go modules
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 
-## 📁 Project Structure Created
+## 📁 Available Templates
 
-When you run the scaffold, it creates the following structure:
+### Full Template (default)
+Complete web application with API, services, repositories, and templates.
 
 ```
 your-project-name/
@@ -34,6 +36,74 @@ your-project-name/
 └── go.mod                   # Go module file
 ```
 
+### CLI Template
+Simple command-line interface tool.
+
+```
+your-project-name/
+├── cmd/
+│   └── main.go              # CLI entry point
+├── pkg/                     # Utilities
+├── .gitignore
+├── README.md
+└── go.mod
+```
+
+### API Template
+REST API server with clean architecture.
+
+```
+your-project-name/
+├── cmd/
+│   └── main.go              # Server entry point
+├── internal/
+│   ├── api/                 # API handlers
+│   ├── service/             # Business logic
+│   ├── repository/          # Data access
+│   └── domain/              # Models
+├── pkg/
+├── configs/
+│   └── config.yaml
+├── .gitignore
+├── README.md
+└── go.mod
+```
+
+### Lib Template
+Go library/package.
+
+```
+your-project-name/
+├── pkg/
+│   └── example.go           # Library code
+├── .gitignore
+├── README.md
+└── go.mod
+```
+
+## 📁 Project Structure (Scaffold Tool)
+
+```
+go_scaffold/
+├── cmd/
+│   └── main.go              # Cobra CLI application entry point
+├── internal/
+│   └── templates/           # Template implementations
+│       ├── templates.go     # Base template interface and utilities
+│       ├── registry.go      # Template registry
+│       ├── full.go          # Full-stack template
+│       ├── cli.go           # CLI template
+│       ├── api.go           # API template
+│       └── lib.go           # Library template
+├── bin/                     # Built executables
+├── configs/                 # Configuration files
+├── scripts/                 # Build scripts
+├── .gitignore
+├── README.md
+├── go.mod
+└── go.sum
+```
+
 ## 🛠️ Installation
 
 ### Prerequisites
@@ -49,143 +119,31 @@ your-project-name/
    go build -o bin/go_scaffold ./cmd
    ```
 
-### Add to PATH (Windows)
-
-To use the scaffold from any directory, add it to your PATH:
-
-```powershell
-# For current session
-$env:PATH += ";path\to\go_scaffold\bin"
-
-# Permanently (run in PowerShell as Administrator)
-setx PATH "%PATH%;path\to\go_scaffold\bin"
-```
-
-### Add to PATH (macOS/Linux)
-
-```bash
-# Add to your shell profile (.bashrc, .zshrc, etc.)
-export PATH="$PATH:path/to/go_scaffold/bin"
-
-# Or create a symlink to a directory in PATH
-sudo ln -s path/to/go_scaffold/bin/go_scaffold /usr/local/bin/go_scaffold
-```
-
 ## 📖 Usage
 
 ### Basic Usage
-
 ```bash
-# Create a new Go project
-go_scaffold my-awesome-project
+# Create a full-stack project
+go_scaffold full my-web-app
 
-# This creates a directory called 'my-awesome-project' with the full structure
+# Create a CLI tool
+go_scaffold cli my-cli-tool
+
+# Create an API server
+go_scaffold api my-api
+
+# Create a library
+go_scaffold lib my-library
+
+# List available templates
+go_scaffold list
 ```
 
-### Example Workflow
-
+### Help
 ```bash
-# 1. Create new project
-go_scaffold my-web-app
+# General help
+go_scaffold --help
 
-# 2. Navigate to the new project
-cd my-web-app
-
-# 3. Install dependencies
-go mod tidy
-
-# 4. Run the application
-go run cmd/main.go
+# Help for specific template
+go_scaffold full --help
 ```
-
-The scaffold will create:
-- A basic HTTP server listening on port 8080
-- Configuration file with database and server settings
-- Proper Go module initialization
-- Git ignore file with common Go exclusions
-
-## ⚙️ Configuration
-
-The scaffold creates a `configs/config.yaml` file with default settings:
-
-```yaml
-server:
-  port: 8080
-
-database:
-  host: "localhost"
-  port: 5432
-  user: "postgres"
-  password: "password"
-  dbname: "yourdb"
-```
-
-Modify these settings according to your needs.
-
-## 🏗️ Architecture Overview
-
-The scaffold follows a clean architecture pattern:
-
-- **`cmd/`**: Application entry points
-- **`internal/`**: Private application code
-  - `api/`: HTTP handlers and routing
-  - `service/`: Business logic
-  - `repository/`: Data persistence layer
-  - `domain/`: Core business entities
-- **`pkg/`**: Public packages that can be imported by other projects
-- **`configs/`**: Configuration files
-- **`web/`**: Web assets and templates
-- **`scripts/`**: Build, deployment, and utility scripts
-
-## 🔧 Development
-
-### Building
-
-```bash
-# Build for current platform
-go build -o bin/go_scaffold ./cmd
-
-# Build for multiple platforms
-GOOS=linux GOARCH=amd64 go build -o bin/go_scaffold-linux ./cmd
-GOOS=darwin GOARCH=amd64 go build -o bin/go_scaffold-mac ./cmd
-GOOS=windows GOARCH=amd64 go build -o bin/go_scaffold.exe ./cmd
-```
-
-### Testing
-
-```bash
-go test ./...
-```
-
-## 📝 Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests if applicable
-5. Submit a pull request
-
-## 📄 License
-
-This project is open source. Feel free to use and modify as needed.
-
-## 🆘 Troubleshooting
-
-### Command not found
-If `go_scaffold` is not recognized:
-- Ensure the `bin` directory is in your PATH
-- Try using the full path: `path/to/go_scaffold/bin/go_scaffold`
-- Restart your terminal after PATH changes
-
-### Build errors
-- Ensure you have Go 1.19+ installed
-- Run `go mod tidy` to download dependencies
-- Check that you're in the correct directory
-
-### Permission errors
-- On Windows: Run PowerShell/Command Prompt as Administrator
-- On macOS/Linux: Use `sudo` for system-wide PATH changes
-
----
-
-**Happy coding! 🎉**

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module go_scaffold
 
 go 1.25.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.1 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/templates/api.go
+++ b/internal/templates/api.go
@@ -1,0 +1,84 @@
+package templates
+
+// APITemplate represents the REST API server template
+type APITemplate struct {
+	BaseTemplate
+}
+
+func NewAPITemplate() *APITemplate {
+	return &APITemplate{
+		BaseTemplate: BaseTemplate{
+			name:        "api",
+			description: "REST API server",
+			dirs: []string{
+				"cmd",
+				"internal/api",
+				"internal/service",
+				"internal/repository",
+				"internal/domain",
+				"pkg",
+				"configs",
+			},
+			files: map[string]string{
+				"cmd/main.go": `package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"%s/internal/api"
+)
+
+func main() {
+	fmt.Println("API Server is starting on :8080...")
+
+	// Setup routes
+	http.HandleFunc("/api/health", api.HealthCheck)
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("Could not start server: %%s\n", err)
+	}
+}
+`,
+				"internal/api/handlers.go": `package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// HealthCheck handles health check requests
+func HealthCheck(w http.ResponseWriter, r *http.Request) {
+	response := map[string]string{"status": "ok"}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+`,
+				".gitignore": `# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with 'go test -c'
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+`,
+				"README.md": "# %s\n\n_Project created on: %date%_\n\n## Description\n\nA REST API server.\n\n## Getting Started\n\n1. Install dependencies: `go mod tidy`\n2. Run the server: `go run cmd/main.go`\n",
+				"configs/config.yaml": `server:
+  port: 8080
+`,
+			},
+		},
+	}
+}

--- a/internal/templates/cli.go
+++ b/internal/templates/cli.go
@@ -1,0 +1,61 @@
+package templates
+
+// CLITemplate represents the command-line interface tool template
+type CLITemplate struct {
+	BaseTemplate
+}
+
+func NewCLITemplate() *CLITemplate {
+	return &CLITemplate{
+		BaseTemplate: BaseTemplate{
+			name:        "cli",
+			description: "Command-line interface tool",
+			dirs: []string{
+				"cmd",
+				"pkg",
+			},
+			files: map[string]string{
+				"cmd/main.go": `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: mycli <command>")
+		os.Exit(1)
+	}
+
+	command := os.Args[1]
+	switch command {
+	case "hello":
+		fmt.Println("Hello, World!")
+	default:
+		fmt.Printf("Unknown command: %s\n", command)
+		os.Exit(1)
+	}
+}
+`,
+				".gitignore": `# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with 'go test -c'
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Go workspace file
+go.work
+`,
+				"README.md": "# %s\n\n_Project created on: %date%_\n\n## Description\n\nA command-line tool.\n\n## Usage\n\n`go run cmd/main.go hello`\n",
+			},
+		},
+	}
+}

--- a/internal/templates/full.go
+++ b/internal/templates/full.go
@@ -1,0 +1,78 @@
+package templates
+
+// FullTemplate represents the full-stack web application template
+type FullTemplate struct {
+	BaseTemplate
+}
+
+func NewFullTemplate() *FullTemplate {
+	return &FullTemplate{
+		BaseTemplate: BaseTemplate{
+			name:        "full",
+			description: "Full-stack web application with API, services, and templates",
+			dirs: []string{
+				"cmd",
+				"internal/api",
+				"internal/service",
+				"internal/repository",
+				"internal/domain",
+				"pkg",
+				"configs",
+				"web/templates",
+				"scripts",
+			},
+			files: map[string]string{
+				"cmd/main.go": `package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	fmt.Println("Server is starting on :8080...")
+	// Example of a simple handler
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, World!")
+	})
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("Could not start server: %s\n", err)
+	}
+}
+`,
+				".gitignore": `# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with 'go test -c'
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+`,
+				"README.md": "# %s\n\n_Project created on: %date%_\n\n## Description\n\n(Your project description here)\n\n## Getting Started\n\n1.  **Install Dependencies:**\n\n    `go mod tidy`\n\n2.  **Run the application:**\n\n    `go run cmd/main.go`\n",
+				"configs/config.yaml": `server:
+  port: 8080
+
+database:
+  host: "localhost"
+  port: 5432
+  user: "postgres"
+  password: "password"
+  dbname: "yourdb"
+`,
+			},
+		},
+	}
+}

--- a/internal/templates/lib.go
+++ b/internal/templates/lib.go
@@ -1,0 +1,44 @@
+package templates
+
+// LibTemplate represents the Go library/package template
+type LibTemplate struct {
+	BaseTemplate
+}
+
+func NewLibTemplate() *LibTemplate {
+	return &LibTemplate{
+		BaseTemplate: BaseTemplate{
+			name:        "lib",
+			description: "Go library/package",
+			dirs: []string{
+				"pkg",
+			},
+			files: map[string]string{
+				"pkg/example.go": `package pkg
+
+// ExampleFunction is an example function
+func ExampleFunction() string {
+	return "Hello from the library!"
+}
+`,
+				".gitignore": `# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with 'go test -c'
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Go workspace file
+go.work
+`,
+				"README.md": "# %s\n\n_Project created on: %date%_\n\n## Description\n\nA Go library.\n\n## Usage\n\nImport this package in your Go project.\n",
+			},
+		},
+	}
+}

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -1,0 +1,43 @@
+package templates
+
+import "fmt"
+
+// TemplateRegistry holds all available templates
+type TemplateRegistry struct {
+	templates map[string]Template
+}
+
+// NewTemplateRegistry creates a new template registry
+func NewTemplateRegistry() *TemplateRegistry {
+	return &TemplateRegistry{
+		templates: map[string]Template{
+			"full": NewFullTemplate(),
+			"cli":  NewCLITemplate(),
+			"api":  NewAPITemplate(),
+			"lib":  NewLibTemplate(),
+		},
+	}
+}
+
+// GetTemplate returns a template by name
+func (r *TemplateRegistry) GetTemplate(name string) (Template, error) {
+	template, exists := r.templates[name]
+	if !exists {
+		return nil, fmt.Errorf("template '%s' not found", name)
+	}
+	return template, nil
+}
+
+// ListTemplates returns all available template names
+func (r *TemplateRegistry) ListTemplates() []string {
+	names := make([]string, 0, len(r.templates))
+	for name := range r.templates {
+		names = append(names, name)
+	}
+	return names
+}
+
+// GetTemplateInfo returns information about a template
+func (r *TemplateRegistry) GetTemplateInfo(name string) (Template, error) {
+	return r.GetTemplate(name)
+}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -1,0 +1,112 @@
+package templates
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Template defines the interface for project templates
+type Template interface {
+	Name() string
+	Description() string
+	Dirs() []string
+	Files() map[string]string
+}
+
+// BaseTemplate provides common functionality for all templates
+type BaseTemplate struct {
+	name        string
+	description string
+	dirs        []string
+	files       map[string]string
+}
+
+func (t *BaseTemplate) Name() string {
+	return t.name
+}
+
+func (t *BaseTemplate) Description() string {
+	return t.description
+}
+
+func (t *BaseTemplate) Dirs() []string {
+	return t.dirs
+}
+
+func (t *BaseTemplate) Files() map[string]string {
+	return t.files
+}
+
+// CreateProject creates a new project using the template
+func CreateProject(template Template, projectName string) error {
+	fmt.Printf("🚀 Scaffolding new Go project: %s using template: %s\n", projectName, template.Name())
+
+	// Create directories
+	for _, dir := range template.Dirs() {
+		fullPath := filepath.Join(projectName, dir)
+		if err := createDir(fullPath); err != nil {
+			return fmt.Errorf("failed to create directory %s: %v", fullPath, err)
+		}
+	}
+
+	// Create files
+	for path, content := range template.Files() {
+		fullPath := filepath.Join(projectName, path)
+		processedContent := processContent(content, projectName)
+		if err := createFile(fullPath, processedContent); err != nil {
+			return fmt.Errorf("failed to create file %s: %v", fullPath, err)
+		}
+	}
+
+	// Initialize Go module
+	fmt.Println("▶️  Running 'go mod init'...")
+	cmd := exec.Command("go", "mod", "init", projectName)
+	cmd.Dir = projectName
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to run 'go mod init': %s\n%v", string(output), err)
+	}
+
+	fmt.Println("\n✅ Project scaffolding complete!")
+	fmt.Printf("📂 Your new project is ready in the '%s' directory.\n", projectName)
+	fmt.Println("\nNext Steps:")
+	fmt.Printf("1. Change into the new directory: cd %s\n", projectName)
+	fmt.Println("2. Install dependencies: go mod tidy")
+
+	return nil
+}
+
+// processContent replaces placeholders in template content
+func processContent(content, projectName string) string {
+	content = strings.ReplaceAll(content, "%s", projectName)
+	content = strings.ReplaceAll(content, "%date%", time.Now().Format("2006-01-02"))
+	return content
+}
+
+// createDir creates a directory if it doesn't already exist
+func createDir(path string) error {
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return fmt.Errorf("could not create directory %s: %w", path, err)
+	}
+	fmt.Printf("✔️  Created directory: %s\n", path)
+	return nil
+}
+
+// createFile creates a new file with the given content
+func createFile(path, content string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("could not create file %s: %w", path, err)
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	if err != nil {
+		return fmt.Errorf("could not write to file %s: %w", path, err)
+	}
+	fmt.Printf("✔️  Created file:      %s\n", path)
+	return nil
+}


### PR DESCRIPTION
Enhance the Go Scaffold tool by implementing multiple project templates including full-stack, CLI, API, and library options. Update the README to reflect these changes and improve the command-line interface for better usability. Additionally, establish a template registry for managing available templates.